### PR TITLE
Add run_exports to 2.5.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
   track_features:
     - rb{{ major_minor | replace(".", "") }}


### PR DESCRIPTION
- Without it, a gem built using conda-build would not be 
    found if installed in ruby 2.6.x series.

  - 2.5.5 build 0 should be moved to broken after this PR is merged.