### PR TITLE
Fix conflict between isinf macro defined by Ruby and std::isinf

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 gmp:
 - '6'
 libffi:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 gmp:
 - '6'
 libffi:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '8'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 gmp:
 - '6'
 libffi:

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_
     UPLOAD_PACKAGES: True

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/recipe/fix-isinf-redefinition-msvc.patch
+++ b/recipe/fix-isinf-redefinition-msvc.patch
@@ -1,0 +1,25 @@
+From 657c28576cbe881afee43b630e2c359ebe471352 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Tue, 10 Nov 2020 23:02:43 +0100
+Subject: [PATCH] Define HAVE_ISINF for Visual Studio >= 2013
+
+isinf is defined in Visual Studio since version 2013.
+---
+ win32/Makefile.sub | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/win32/Makefile.sub b/win32/Makefile.sub
+index 9686d1caaa77..31dc25f3d33f 100644
+--- a/win32/Makefile.sub
++++ b/win32/Makefile.sub
+@@ -817,6 +817,9 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
+ #define HAVE_STRCHR 1
+ #define HAVE_STRSTR 1
+ #define HAVE_FLOCK 1
++!if $(MSC_VER) >= 1800
++#define HAVE_ISINF 1
++!endif
+ #define HAVE_ISNAN 1
+ #define HAVE_FINITE 1
+ !if $(RT_VER) >= 120
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
     # Patches/work-arounds for passing make check
     - disable-backtrace-with-lines.patch
     - fix-inline-redefinition-msvc.patch  # [win]
+    - fix-isinf-redefinition-msvc.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   track_features:
     - rb{{ major_minor | replace(".", "") }}
   run_exports:


### PR DESCRIPTION
Fix https://github.com/conda-forge/ruby-feedstock/issues/47 by backporting https://github.com/ruby/ruby/pull/3758 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
