### PR TITLE
Allow noarch ruby packages

### DIFF
--- a/.ci_support/migrations/libffi33.yaml
+++ b/.ci_support/migrations/libffi33.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libffi:
-- '3.3'
-migrator_ts: 1606336603.4597452

--- a/recipe/activate.msh
+++ b/recipe/activate.msh
@@ -1,7 +1,2 @@
-if_(is_set("COMSPEC")).then_([
-	export("GEM_HOME", path.join(env("CONDA_PREFIX"), "Library/share/rubygems")),
-	sys.path_prepend(path.join(env("CONDA_PREFIX"), "Library/share/rubygems/bin"))
-]).else_([
-	export("GEM_HOME", path.join(env("CONDA_PREFIX"), "share/rubygems")),
-	sys.path_prepend(path.join(env("CONDA_PREFIX"), "share/rubygems/bin"))
-])
+export("GEM_HOME", path.join(env("CONDA_PREFIX"), "share/rubygems")),
+sys.path_prepend(path.join(env("CONDA_PREFIX"), "share/rubygems/bin"))

--- a/recipe/activate.ps1
+++ b/recipe/activate.ps1
@@ -1,7 +1,2 @@
-if (Test-Path env:COMSPEC) {
-    $Env:GEM_HOME=$(Join-Path -Path $Env:CONDA_PREFIX -ChildPath Library/share/rubygems)
-    $Env:PATH="$(Join-Path -Path $Env:CONDA_PREFIX -ChildPath Library/share/rubygems/bin);$Env:PATH"
-} else {
-    $Env:GEM_HOME=$(Join-Path -Path $Env:CONDA_PREFIX -ChildPath share/rubygems)
-    $Env:PATH="$(Join-Path -Path $Env:CONDA_PREFIX -ChildPath share/rubygems/bin);$Env:PATH"
-}
+$Env:GEM_HOME=$(Join-Path -Path $Env:CONDA_PREFIX -ChildPath share/rubygems)
+$Env:PATH="$(Join-Path -Path $Env:CONDA_PREFIX -ChildPath share/rubygems/bin);$Env:PATH"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,7 +1,2 @@
-if [ -z "$COMSPEC" ]; then
-	export GEM_HOME=$CONDA_PREFIX/share/rubygems/
-	export PATH="$CONDA_PREFIX/share/rubygems/bin:$PATH"
-else
-	export GEM_HOME=$CONDA_PREFIX/Library/share/rubygems/
-	export PATH="$CONDA_PREFIX/Library/share/rubygems/bin:$PATH"
-fi
+export GEM_HOME=$CONDA_PREFIX/share/rubygems/
+export PATH="$CONDA_PREFIX/share/rubygems/bin:$PATH"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,7 @@ setlocal enableextensions
 
 RMDIR /s /q ext\fiddle\libffi-3.2.1
 
-CALL win32\configure.bat --prefix=%LIBRARY_PREFIX%
+CALL win32\configure.bat --prefix=%PREFIX%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 nmake
@@ -11,13 +11,13 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 nmake install
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-mkdir %LIBRARY_PREFIX%\etc
+mkdir %PREFIX%\etc
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-mkdir %LIBRARY_PREFIX%\share\rubygems
+mkdir %PREFIX%\share\rubygems
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-echo "gemhome: %LIBRARY_PREFIX%/share/rubygems" > %LIBRARY_PREFIX%/etc/gemrc
+echo "gemhome: %PREFIX%/share/rubygems" > %PREFIX%/etc/gemrc
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 setlocal EnableDelayedExpansion

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -29,4 +29,4 @@ goto :EOF
 
 :start
 set GEM_HOME=
-call :removeFromPath "%CONDA_PREFIX%\Library\share\rubygems\bin"
+call :removeFromPath "%CONDA_PREFIX%\share\rubygems\bin"

--- a/recipe/deactivate.msh
+++ b/recipe/deactivate.msh
@@ -1,3 +1,2 @@
 unset(env("GEM_HOME"))
-sys.path_remove(path.join(env("CONDA_PREFIX"), "Library/share/rubygems/bin"))
 sys.path_remove(path.join(env("CONDA_PREFIX"), "share/rubygems/bin"))

--- a/recipe/deactivate.ps1
+++ b/recipe/deactivate.ps1
@@ -1,6 +1,4 @@
 try { Remove-Item env:GEM_HOME}
 catch { Write-Host "Failed to execute Remove-Item env:GEM_HOME" }
-$rmpath = $(Join-Path -Path $Env:CONDA_PREFIX -ChildPath Library/share/rubygems/bin)
-$Env:PATH = ($Env:PATH.Split(';') | Where-Object { $_ -ne $rmpath }) -join ';'
 $rmpath = $(Join-Path -Path $Env:CONDA_PREFIX -ChildPath share/rubygems/bin)
 $Env:PATH = ($Env:PATH.Split(';') | Where-Object { $_ -ne $rmpath }) -join ';'

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,6 +1,5 @@
 if [ "$ZSH_VERSION" != "" ]; then
     unset GEM_HOME
-    path=(${path[@]:#"$CONDA_PREFIX/Library/share/rubygems/bin"})
     path=(${path[@]:#"$CONDA_PREFIX/share/rubygems/bin"})
 else
     # Taken from http://www.linuxfromscratch.org/blfs/view/svn/postlfs/profile.html
@@ -19,6 +18,5 @@ else
             export $PATHVARIABLE="$NEWPATH"
     }
     unset GEM_HOME
-    pathremove "$CONDA_PREFIX/Library/share/rubygems/bin"
     pathremove "$CONDA_PREFIX/share/rubygems/bin"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - fix-isinf-redefinition-msvc.patch  # [win]
 
 build:
-  number: 3
+  number: 4
   track_features:
     - rb{{ major_minor | replace(".", "") }}
   run_exports:


### PR DESCRIPTION
As most ruby packages are "noarch" packages, I think the installation prefixes should be the same for all platforms (so GEM_HOME is the same on all platforms).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
