### PR TITLE
Enable fiddle extension also on Windows

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,9 +6,13 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2017
+libffi:
+- '3.4'
 openssl:
 - 1.1.1
 pin_run_as_build:
+  libffi:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/build-locally.py
+++ b/build-locally.py
@@ -22,6 +22,10 @@ def setup_environment(ns):
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
         )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
+        )
 
 
 def run_docker_build(ns):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - autoconf    # [unix]
     - automake    # [unix]
     - make        # [unix]
-    - pkg-config  # [unix]
+    - pkg-config
     # We need all host deps also in build for cross-compiling
     - gettext     # [build_platform != target_platform]
     - gmp         # [build_platform != target_platform]
@@ -47,7 +47,7 @@ requirements:
     - gdbm        # [x86 and unix]
     - gettext     # [osx]
     - gmp         # [unix]
-    - libffi      # [unix]
+    - libffi
     - ncurses     # [unix]
     - openssl
     - readline    # [unix]
@@ -69,7 +69,8 @@ test:
     - gem --version
     - ruby -e 'puts "Hi, from Ruby!"'
     - ruby -r rubygems -e 'puts "Has gems."; exit 0'
-    - ruby -r fiddle -r openssl -r readline -r yaml -r zlib -e 'puts "Has all dependencies."; exit 0'  # [unix]
+    - ruby -r fiddle -r openssl -r yaml -r zlib -e 'puts "Has all dependencies."; exit 0'
+    - ruby -r readline -e 'puts "Has readline."; exit 0'  # [unix]
 
     # Tests it can build libraries with native dependencies
     - cd native                        # [unix]


### PR DESCRIPTION
Required by https://github.com/conda-forge/libignition-tools-feedstock/pull/12#issuecomment-954826254 . As the fiddle extentions is using `libffi` that is found by the custom build script via `pkg-config`, this PR enables the `libffi` and `pkg-config` dependencies also on Windows.

Tests have been added to ensure that the `fiddle` extention indeed loads fine.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
